### PR TITLE
Main

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -36,7 +36,7 @@ RecipesBase = "0.7,1"
 StatsBase = "0.32,0.33"
 TextParse = "0.9.1,1"
 WeakRefStrings = "0.6"
-julia = "1"
+julia = "1.6"
 
 [extras]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"

--- a/src/io.jl
+++ b/src/io.jl
@@ -240,7 +240,7 @@ deserialize(io::AbstractSerializer, DT::Type{DIndexedTable{T,K}}) where {T,K} = 
 function _deser(io::AbstractSerializer, t)
     nf = fieldcount(t)
     x = ccall(:jl_new_struct_uninit, Any, (Any,), t)
-    t.mutable && Serialization.deserialize_cycle(io, x)
+    ismutabletype(t) && Serialization.deserialize_cycle(io, x)
     for i in 1:nf
         tag = Int32(read(io.io, UInt8)::UInt8)
         if tag != Serialization.UNDEFREF_TAG


### PR DESCRIPTION
Fix bug (https://github.com/JuliaData/JuliaDB.jl/issues/408) that causes loading from a bin directory to fail due to deprecated type mutability check.

Changes:
- Update `IO.jl` to use `ismutabletype()`
- Change Julia compat bound to 1.6